### PR TITLE
Fix backend start script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
    "main": "index.js",
    "scripts": {
       "test": "echo \"Error: no test specified\" && exit 1",
-      "start": "ts-node src/index.ts"
+      "start": "ts-node src/server.ts"
    },
    "keywords": [],
    "author": "",


### PR DESCRIPTION
The start script references `src/index.ts` which does not exist.
`src/server.ts` does exist so we will use that.